### PR TITLE
adjust regex in duplicate check

### DIFF
--- a/app/code/community/EcomDev/UrlRewrite/Model/Mysql4/Indexer.php
+++ b/app/code/community/EcomDev/UrlRewrite/Model/Mysql4/Indexer.php
@@ -1571,7 +1571,7 @@ class EcomDev_UrlRewrite_Model_Mysql4_Indexer extends Mage_Index_Model_Mysql4_Ab
                 'IF(rewrite.duplicate_index IS NOT NULL ' 
                     . ' AND SUBSTRING_INDEX(rewrite.duplicate_key, ?, -1) = SUBSTRING_INDEX(request_path.request_path, ?, -1), '
                     . ' rewrite.duplicate_index, '
-                    . ' IF(request_path.request_path REGEXP \'[0-9]$\', 0, NULL))',
+                    . ' IF(request_path.request_path REGEXP \'-[0-9]$\', 0, NULL))',
                 '/'
             )),
             'updated' => new Zend_Db_Expr('1'),
@@ -1593,7 +1593,7 @@ class EcomDev_UrlRewrite_Model_Mysql4_Indexer extends Mage_Index_Model_Mysql4_Ab
         unset($columns['request_path.updated']);
         
         $columns['duplicate_index'] = new Zend_Db_Expr(
-            'IF(request_path.request_path REGEXP \'[0-9]$\', 0, NULL)'
+            'IF(request_path.request_path REGEXP \'-[0-9]$\', 0, NULL)'
         );
         
         $columns = array(
@@ -1682,7 +1682,7 @@ class EcomDev_UrlRewrite_Model_Mysql4_Indexer extends Mage_Index_Model_Mysql4_Ab
                 'IF(rewrite.duplicate_index IS NOT NULL ' 
                     . ' AND SUBSTRING_INDEX(rewrite.duplicate_key, ?, -1) = SUBSTRING_INDEX(request_path.request_path, ?, -1), '
                     . ' rewrite.duplicate_index, '
-                    . ' IF(request_path.request_path REGEXP \'[0-9]$\', 0, NULL))',
+                    . ' IF(request_path.request_path REGEXP \'-[0-9]$\', 0, NULL))',
                 '/'
             )),
             'target_path' => $targetPathExpr,
@@ -1706,7 +1706,7 @@ class EcomDev_UrlRewrite_Model_Mysql4_Indexer extends Mage_Index_Model_Mysql4_Ab
         unset($columns['request_path.updated']);
         
         $columns['duplicate_index'] = new Zend_Db_Expr(
-            'IF(request_path.request_path REGEXP \'[0-9]$\', 0, NULL)'
+            'IF(request_path.request_path REGEXP \'-[0-9]$\', 0, NULL)'
         );
         
         $columns = array(


### PR DESCRIPTION
The regex used to find duplicate url_keys are giving false positives if the given url_key ends in -[number]

for example:

`19th-century-filipino-basket-with-lid-acc-7311-5219` would result in `19th-century-filipino-basket-with-lid-acc-7311-5219-1.html` as the request url.
